### PR TITLE
Added validation to prevent button bugs

### DIFF
--- a/index.js
+++ b/index.js
@@ -117,46 +117,73 @@ function changeDirection(e) {
   }
 }
 
+function isOppositeDirection(gameState) {
+  if (gameState.lastDirection == "right" && gameState.direction == 'left') {
+    return true;
+  } else if (gameState.lastDirection == "up" && gameState.direction == 'down') {
+    return true;
+  } else if (gameState.lastDirection == "left" && gameState.direction == 'right') {
+    return true;
+  } else if (gameState.lastDirection == "down" && gameState.direction == 'up') {
+    return true;
+  } else {
+    return false;
+  }
+}
+
 function move() {
   let lastCell = gameState.snake[gameState.snakeLength - 1];
   let start;
   if (gameState.direction === "right") {
+    gameState.lastStart = gameState.snakeStart;
     start = gameState.snakeStart + 1;
     if (start % boardWidth === 0) {
       gameOver();
       return;
     }
   } else if (gameState.direction === "left") {
+    gameState.lastStart = gameState.snakeStart;
     start = gameState.snakeStart - 1;
     if (start < 0 || start % boardWidth === boardWidth - 1) {
       gameOver();
       return;
     }
   } else if (gameState.direction === "up") {
+    gameState.lastStart = gameState.snakeStart;
     start = gameState.snakeStart - boardWidth;
     if (start < 0) {
       gameOver();
       return;
     }
   } else if (gameState.direction === "down") {
+    gameState.lastStart = gameState.snakeStart;
     start = gameState.snakeStart + boardWidth;
     if (start > boardWidth * boardHeight) {
       gameOver();
       return;
     }
   }
-  if (gameState.snake.includes(start)) {
-    gameOver();
-    return;
+
+  if (isOppositeDirection(gameState)) {
+    gameState.snakeStart = gameState.lastStart;
+    gameState.direction = gameState.lastDirection;
+    drawSnake(gameState.snakeLength);
+  } else {
+    if (gameState.snake.includes(start)) {
+      gameOver();
+      return;
+    }
+
+    gameState.snakeStart = start;
+    gameState.snake.unshift(start);
+    gameState.lastDirection = gameState.direction;
+    let ateFood = eatFood();
+    if (!ateFood) {
+      updateSnakeCell("remove", lastCell);
+      gameState.snake.pop();
+    }
+    drawSnake(gameState.snakeLength);
   }
-  gameState.snakeStart = start;
-  gameState.snake.unshift(start);
-  let ateFood = eatFood();
-  if (!ateFood) {
-    updateSnakeCell("remove", lastCell);
-    gameState.snake.pop();
-  }
-  drawSnake(gameState.snakeLength);
 }
 
 let intervalId;


### PR DESCRIPTION
Hi @indremak ,

I've found out that this bug is due to the setInterval. The setInterval somewhat delays the register of key inputs, that is why when you press the buttons fast enough, only one button registers.

Now, this also affects the game over validation:

```
if (gameState.snake.includes(start)) {
    gameOver();
    return;
}
```

This is because on the start, the snake moves to the right, and once you press the up and left button quickly, only the left button registers and causes the snake to go back to the previous direction. This also applies to other cases in which the buttons pressed registers a direction opposite to the current snake direction.

To fix this I've created a simple checker if the keystrokes register a movement opposite to the current direction. This condition bypasses the game over condition stated above and restores the snake to its previous game state.

I hope this simple fix helps solve this problem :D :D :D