### PR TITLE
prevent default keypress behaviour to avoid scrolling while playing

### DIFF
--- a/index.js
+++ b/index.js
@@ -172,6 +172,8 @@ function handleInput(e) {
       addNewDirection("up");
     }
   }
+  // The arrow keys can scroll the window while playing, we disable this
+  e.preventDefault();
 }
 
 let xDown = null;


### PR DESCRIPTION
Hello there :)

I noticed that the browser window is scrolling at up and down keypresses, which should not be happening for such a game that's controlled by the arrow keys. This one-liner disables this behaviour.

cheers,
ditam