### PR TITLE
maintain hard mode switch state during init

### DIFF
--- a/index.js
+++ b/index.js
@@ -441,9 +441,7 @@ function init() {
   drawSnake();
   updateFoodCell("add", gameState.food);
   startGame();
-  hardModeCheckbox.checked = false;
   desc.style.opacity = "0";
-  hardMode = 0;
 }
 
 document.addEventListener("keydown", handleInput);


### PR DESCRIPTION
Hi

It is counter-intuitive that the hard mode turns off when you restart the game. If somebody wants to play in hard mode, they shouldn't need to toggle it again and again.

This update allows the hard mode state to persist during a restart. (The removed lines are also not necessary for the first `init()` call either: the variable `hardMode` is correctly initialized as 0, and the checkbox as unchecked.)

cheers,
ditam